### PR TITLE
Missing library, more flexible URLs.

### DIFF
--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -476,7 +476,7 @@ function islandora_openseadragon_iiif_pid_tile_source($pid, $dsid, $token) {
   $identifier = \Drupal::token()->replace($identifier_tokens, islandora_openseadragon_create_replacement_array($pid, $dsid, $token));
   $base_url = rtrim(\Drupal::config('islandora_openseadragon.settings')->get('islandora_openseadragon_iiif_url'), '/');
   $identifier_encoded = urlencode($identifier);
-  return file_create_url("$base_url/$identifier_encoded/info.json");
+  return Url::fromUri("$base_url/$identifier_encoded/info.json")->toString();
 }
 
 /**

--- a/islandora_openseadragon.libraries.yml
+++ b/islandora_openseadragon.libraries.yml
@@ -11,6 +11,7 @@ viewer:
   dependencies:
     - islandora_openseadragon/openseadragon
     - core/jquery
+    - core/jquery.once
     - core/drupalSettings
     - core/drupal
 djatoka-viewer:
@@ -24,5 +25,6 @@ djatoka-viewer:
   dependencies:
     - islandora_openseadragon/openseadragon
     - core/jquery
+    - core/jquery.once
     - core/drupalSettings
     - core/drupal


### PR DESCRIPTION
[We use the .once library in the existing code](https://github.com/discoverygarden/islandora_openseadragon/blob/57d2d9630c846374df0d8d6cabd7a7d13c52ef1e/js/islandora_openseadragon.js#L24), and by more "flexible" URLs, we can now use things like "base:iiif/2" to make references relative to the root of the Drupal site, to avoid requiring knowledge of our own hostname inside of our configuration.