### PR TITLE
More extensive cache context for the viewer.

### DIFF
--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -115,7 +115,7 @@ function islandora_openseadragon_construct_clip_url($params, $download = FALSE) 
   }
   else {
     $identifier = $decoded_params['identifier'];
-    $region = $decoded_params['svc.region'];
+    $region = $decoded_params['region'];
     $size = $decoded_params['size'];
     $rotation = 0;
     $format = "default.jpg";

--- a/islandora_openseadragon.module
+++ b/islandora_openseadragon.module
@@ -7,6 +7,7 @@
 
 use Drupal\Core\Url;
 use Drupal\Component\Utility\Xss;
+use Drupal\user\Entity\User;
 
 // @codingStandardsIgnoreStart
 const ISLANDORA_OPENSEADRAGON_REQUIRED_VERSION = '2.3.1';
@@ -96,8 +97,13 @@ function islandora_openseadragon_callback(array $params = [], AbstractObject $ob
   }
 
   if (isset($params['pid']) && isset($params['dsid']) && isset($params['token'])) {
-    $token_header = \Drupal::config('islandora_openseadragon.settings')->get('islandora_openseadragon_tilesource') == 'iiif'
-      && \Drupal::config('islandora_openseadragon.settings')->get('islandora_openseadragon_iiif_token_header');
+    $renderer = \Drupal::service('renderer');
+    $config = \Drupal::config('islandora_openseadragon.settings');
+
+    $param_object = islandora_object_load($params['pid']);
+
+    $token_header = $config->get('islandora_openseadragon_tilesource') == 'iiif'
+      && $config->get('islandora_openseadragon_iiif_token_header');
     $settings = islandora_openseadragon_get_viewer_settings(
       [
         'pid' => $params['pid'],
@@ -117,8 +123,20 @@ function islandora_openseadragon_callback(array $params = [], AbstractObject $ob
           'islandoraOpenSeadragon' => $settings,
         ],
       ],
+      '#cache' => [
+        'contexts' => [
+          'user',
+        ],
+      ],
     ];
-    return \Drupal::service('renderer')->render($viewer);
+
+    $renderer->addCacheableDependency($viewer, $config);
+    $renderer->addCacheableDependency($viewer, $object);
+    $renderer->addCacheableDependency($viewer, $param_object);
+    $renderer->addCacheableDependency($viewer, $param_object[$params['dsid']]);
+    $renderer->addCacheableDependency($viewer, User::load(\Drupal::currentUser()->id()));
+
+    return $renderer->render($viewer);
   }
 }
 

--- a/islandora_openseadragon.module
+++ b/islandora_openseadragon.module
@@ -127,14 +127,20 @@ function islandora_openseadragon_callback(array $params = [], AbstractObject $ob
         'contexts' => [
           'user',
         ],
+        // XXX: Given our response here includes an auth token, let's prevent
+        // caching.
+        'max-age' => 0,
       ],
     ];
 
     $renderer->addCacheableDependency($viewer, $config);
+    $renderer->addCacheableDependency($viewer, User::load(\Drupal::currentUser()->id()));
+    // XXX: Our Tuque objects do not (presently) implement the
+    // CacheableDependencyInterface, so adding them effectively prevents
+    // caching of the dependent content.
     $renderer->addCacheableDependency($viewer, $object);
     $renderer->addCacheableDependency($viewer, $param_object);
     $renderer->addCacheableDependency($viewer, $param_object[$params['dsid']]);
-    $renderer->addCacheableDependency($viewer, User::load(\Drupal::currentUser()->id()));
 
     return $renderer->render($viewer);
   }

--- a/islandora_openseadragon.module
+++ b/islandora_openseadragon.module
@@ -154,18 +154,31 @@ function islandora_openseadragon_preprocess_islandora_object_print(array &$varia
     module_load_include('inc', 'islandora_openseadragon', 'includes/utilities');
     $clip_parts = islandora_openseadragon_construct_clip_url($_GET['clip']);
     if ($clip_parts) {
+      $renderer = \Drupal::service('renderer');
       $variables['clip'] = $clip_parts['original_params'];
       $image = [
         '#theme' => 'image',
         '#uri' => $clip_parts['image_url'],
         '#attributes' => $clip_parts['dimensions'],
+        '#cache' => [
+          'contexts' => [
+            'url.query_args',
+            'user',
+          ],
+        ],
       ];
-      $rendered_image = \Drupal::service('renderer')->render($image);
+
       $variables['content']['clip'] = [
         '#weight' => 0,
         '#prefix' => "<div id='clip'>",
-        '#markup' => $rendered_image,
+        '#markup' => $renderer->render($image),
         '#suffix' => '</div>',
+        '#cache' => [
+          'contexts' => [
+            'url.query_args',
+            'user',
+          ],
+        ],
       ];
     }
     else {


### PR DESCRIPTION
Couple of things:
* fix up a regression with the parameter name used by the clipper
* add cache context to the viewer's render array such that it does not cache auth tokens in the render cache, so we do not attempt to reuse expired/fully-consumed tokens