### PR TITLE
Update php version for D8

### DIFF
--- a/islandora_openseadragon.info.yml
+++ b/islandora_openseadragon.info.yml
@@ -8,4 +8,4 @@ package: 'Islandora Viewers'
 configure: islandora_openseadragon.admin
 core: 8.x
 type: module
-php: '5.5.9'
+php: '7.2'


### PR DESCRIPTION
php 5 support is being dropped:
[Drupal docs](https://www.drupal.org/docs/8/system-requirements/php-requirements)